### PR TITLE
Add checked-in count using useScaffoldReadContract hook

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,23 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
-  const [isLoading, setIsLoading] = useState(true);
-  const { data: checkedInCounter } = useScaffoldReadContract({
+  const { data: checkedInCounter, isLoading } = useScaffoldReadContract({
     contractName: "BatchRegistry",
     functionName: "checkedInCounter",
   });
-
-  useEffect(() => {
-    if (checkedInCounter !== undefined) {
-      setIsLoading(false);
-    }
-  }, [checkedInCounter]);
 
   return (
     <>


### PR DESCRIPTION
## Description

<img width="812" height="395" alt="Screenshot 2025-10-21 at 7 42 50 PM" src="https://github.com/user-attachments/assets/46c221ed-831b-4e41-840c-f568cf2ecee2" />


This PR adds Checked In count of builders for Batch 21 in the frontend home page. Uses useScaffoldReadContract hook to display BatchRegistry contract's checkedInCounter.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{6}_

Your ENS/address: 0xCc016E91e18bA3363aFA443CE0aa492379ea53B2
