### PR TITLE
Showing connected wallet status

### DIFF
--- a/packages/nextjs/components/BuilderStatus.tsx
+++ b/packages/nextjs/components/BuilderStatus.tsx
@@ -1,16 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
 import { zeroAddress } from "viem";
 import { useAccount } from "wagmi";
 import { CheckCircleIcon, ClockIcon, XCircleIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
-
-type StatusConfig = {
-  icon: React.ElementType;
-  color: string;
-  tooltip: string;
-};
 
 export const BuilderStatus = () => {
   const { address: connectedAddress, isConnected } = useAccount();
@@ -28,22 +21,23 @@ export const BuilderStatus = () => {
   });
   const isCheckedIn = contractAddress && contractAddress !== zeroAddress;
 
-  const status = useMemo<StatusConfig>(() => {
-    return !isBatchMember
-      ? { icon: XCircleIcon, color: "text-red-500", tooltip: "🔴 Not a batch member" }
-      : isCheckedIn
-        ? { icon: CheckCircleIcon, color: "text-green-500", tooltip: "🟢 Member checked-in" }
-        : { icon: ClockIcon, color: "text-yellow-500", tooltip: "🟡 Member not checked-in" };
-  }, [isBatchMember, isCheckedIn]);
-
   if (!isConnected) return null;
 
-  const Icon = status.icon;
   return (
     <div className="flex items-center mr-1">
-      <div className="tooltip tooltip-bottom tooltip-primary p-1" data-tip={status.tooltip}>
-        <Icon className={`h-6 w-6 ${status.color}`} />
-      </div>
+      {!isBatchMember ? (
+        <div className="tooltip tooltip-bottom tooltip-primary p-1" data-tip="🔴 Not a batch member">
+          <XCircleIcon className="h-6 w-6 text-red-500" />
+        </div>
+      ) : isCheckedIn ? (
+        <div className="tooltip tooltip-bottom tooltip-primary p-1" data-tip="🟢 Member checked-in">
+          <CheckCircleIcon className="h-6 w-6 text-green-500" />
+        </div>
+      ) : (
+        <div className="tooltip tooltip-bottom tooltip-primary p-1" data-tip="🟡 Member not checked-in">
+          <ClockIcon className="h-6 w-6 text-yellow-500" />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { hardhat } from "viem/chains";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
-import { BuilderStatus, FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
+import { BuilderStatus } from "~~/components/BuilderStatus";
+import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick, useTargetNetwork } from "~~/hooks/scaffold-eth";
 
 type HeaderMenuLink = {

--- a/packages/nextjs/components/scaffold-eth/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/index.tsx
@@ -1,7 +1,6 @@
 export * from "./Address/Address";
 export * from "./Balance";
 export * from "./BlockieAvatar";
-export * from "./BuilderStatus";
 export * from "./Faucet";
 export * from "./FaucetButton";
 export * from "./Input";


### PR DESCRIPTION
## Description

When a user connects a wallet: 
Connected wallet is not in allow list (not this batch member)
<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/4ac4d17a-dab6-48f5-8563-126f89daeb19" />

Connected wallet is a member but has not checked-in yet
<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/3aee4d95-3423-429a-a543-0546e6b0f4d1" />

Member has checked-in
<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/dc004bf8-07c4-4cd0-a19b-44263752f2b2" />

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

#5 

Your ENS/address: 0x2Ef6340900ADbeaECC065777bdd193feF0e5D2E7
