### PR TITLE
add batch 21 graduates component on homepage

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { Batch21Graduates } from "../components/Batch21Graduates";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
@@ -19,6 +20,7 @@ const Home: NextPage = () => {
         <div className="mb-4 flex justify-center">
           <Image src="/batch21.png" alt="Batch 21" width={600} height={200} className="drop-shadow-lg" priority />
         </div>
+        <Batch21Graduates />
         <p className="text-xl md:text-2xl text-white dark:text-gray-300 mb-2 [text-shadow:0_0_24px_rgba(148,163,184,0.95)] dark:[text-shadow:none]">
           Buidling the future, one block at a time.
         </p>

--- a/packages/nextjs/components/Batch21Graduates.tsx
+++ b/packages/nextjs/components/Batch21Graduates.tsx
@@ -1,112 +1,77 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { useRef } from "react";
-import Link from "next/link";
-import { Address } from "~~/components/scaffold-eth/Address/Address";
+import { useEffect, useRef, useState } from "react";
+import { GraduateItem } from "~~/components/GraduateItem";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth";
 import { useScaffoldContract } from "~~/hooks/scaffold-eth/useScaffoldContract";
 import { contracts } from "~~/utils/scaffold-eth/contract";
 
-type Graduate = {
-  tokenId: number;
-  owner: string;
-  tokenURI?: string;
-  name?: string;
-  image?: string;
-};
-
-function decodeBase64Json(dataUrl: string): { name?: string; image?: string } | undefined {
-  try {
-    const prefix = "data:application/json;base64,";
-    if (!dataUrl || !dataUrl.startsWith(prefix)) return undefined;
-    const b64 = dataUrl.slice(prefix.length);
-    const jsonStr = typeof atob === "function" ? atob(b64) : Buffer.from(b64, "base64").toString("utf-8");
-    const json = JSON.parse(jsonStr);
-    return { name: json.name, image: json.image };
-  } catch {
-    return undefined;
-  }
-}
-
 export const Batch21Graduates: React.FC = () => {
   const { targetNetwork } = useTargetNetwork();
-
   const nftEntry = contracts?.[targetNetwork?.id]?.BatchGraduationNFT;
   const nftAddress = nftEntry?.address as `0x${string}` | undefined;
-
-  const [loading, setLoading] = useState(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [graduates, setGraduates] = useState<Graduate[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const hasScanned = useRef(false);
 
   const { data: nftContract } = useScaffoldContract({
     contractName: "BatchGraduationNFT",
     chainId: targetNetwork?.id as any,
   });
 
-  const scan = useCallback(async () => {
-    if (!nftContract) return;
+  const [loading, setLoading] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [maxId, setMaxId] = useState(0);
+  const hasInitialized = useRef(false);
 
-    setLoading(true);
-    setError(null);
-
-    const found: Graduate[] = [];
-
-    try {
-      let id = 1;
-      while (true) {
-        let owner;
-        try {
-          owner = await nftContract.read.ownerOf([BigInt(id)]);
-        } catch {
-          // stops when token doesn't exist
-          break;
-        }
-
-        let rawTokenURI: string | undefined;
-        try {
-          rawTokenURI = await nftContract.read.tokenURI([BigInt(id)]);
-        } catch {
-          rawTokenURI = undefined;
-        }
-
-        const parsed = decodeBase64Json(rawTokenURI ?? "");
-        found.push({
-          tokenId: id,
-          owner,
-          tokenURI: rawTokenURI,
-          name: parsed?.name,
-          image: parsed?.image,
-        });
-
+  async function findMaxMinted(contract: any): Promise<number> {
+    let id = 1;
+    while (true) {
+      try {
+        await contract.read.ownerOf([BigInt(id)]);
         id++;
+      } catch {
+        break;
       }
+    }
+    return id - 1;
+  }
 
-      setGraduates(found);
+  useEffect(() => {
+    if (!nftAddress || !nftContract) return;
+    if (hasInitialized.current) return;
+
+    hasInitialized.current = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const max = await findMaxMinted(nftContract);
+        setMaxId(max);
+        setLastUpdated(new Date());
+      } catch (e: any) {
+        setError(String(e?.message ?? e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [nftAddress, nftContract]);
+
+  const handleRefresh = async () => {
+    if (!nftContract) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const max = await findMaxMinted(nftContract);
+      setMaxId(max);
       setLastUpdated(new Date());
     } catch (e: any) {
       setError(String(e?.message ?? e));
     } finally {
       setLoading(false);
     }
-  }, [nftContract]);
-
-  useEffect(() => {
-    if (!nftAddress || !nftContract) return;
-    if (hasScanned.current) return;
-    hasScanned.current = true;
-    scan();
-  }, [nftAddress, nftContract, scan]);
-
-  const handleRefresh = async () => {
-    setError(null);
-    await scan();
   };
 
   return (
-    <div className="max-w-5xl mx-auto p-4 bg-white/10 backdrop-blur-lg border border-white/20 shadow-lg rounded-2xl">
+    <div className="max-w-5xl mx-auto p-4 my-10 bg-white/10 backdrop-blur-lg border border-white/20 shadow-lg rounded-2xl">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-2xl md:text-3xl font-bold flex items-center gap-2 text-gray-900/90 dark:text-white drop-shadow-sm">
           <span className="text-3xl md:text-4xl">🎓</span>
@@ -125,7 +90,7 @@ export const Batch21Graduates: React.FC = () => {
               <span className="w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse"></span>
               Updated {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
             </div>
-          )}{" "}
+          )}
         </div>
       </div>
 
@@ -135,55 +100,25 @@ export const Batch21Graduates: React.FC = () => {
         <div className="text-sm">Scanning for minted tokens…</div>
       ) : error ? (
         <div className="text-red-600 text-sm">Error: {error}</div>
-      ) : graduates.length === 0 ? (
+      ) : maxId === 0 ? (
         <div className="text-sm">No graduates found yet.</div>
       ) : (
         <div
           className="
-          
             mt-4
-            max-h-[60vh]   
-            md:max-h-[55vh] 
-            sm:max-h-[50vh] 
+            max-h-[60vh]
+            md:max-h-[55vh]
+            sm:max-h-[50vh]
             overflow-y-auto
             scroll-smooth
-            pr-2            
-            -mr-2         
+            pr-2
+            -mr-2
           "
         >
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 items-stretch">
-            {graduates.map(g => {
-              return (
-                <Link key={g.tokenId} href={`/builders/${g.owner}`} className="block mt-4 w-full h-full">
-                  <div
-                    className="
-                      relative bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl 
-                      p-3 sm:p-4               /* smaller padding on xs */
-                      flex flex-col items-center h-full
-                      shadow-[0_0_15px_rgba(99,102,241,0.08)]
-                      transition-all duration-300
-                      hover:shadow-[0_0_25px_rgba(99,102,241,0.18)]
-                      hover:-translate-y-1 hover:border-indigo-300
-                    "
-                  >
-                    <div
-                      className="
-                        text-sm sm:text-sm md:text-base font-semibold text-gray-800 dark:text-gray-200
-                        group-hover:text-indigo-600 transition
-                        max-w-[140px] sm:max-w-[160px] text-center
-                        whitespace-nowrap overflow-hidden text-ellipsis
-                      "
-                    >
-                      <Address address={g.owner} size="sm" disableAddressLink onlyEnsOrAddress />
-                    </div>
-
-                    <div className="mt-1 w-full text-center text-xs text-gray-500 truncate dark:text-gray-200">
-                      {g.name}
-                    </div>
-                  </div>
-                </Link>
-              );
-            })}
+            {Array.from({ length: maxId }).map((_, i) => (
+              <GraduateItem key={i + 1} tokenId={i + 1} chainId={targetNetwork?.id as number} />
+            ))}
           </div>
         </div>
       )}

--- a/packages/nextjs/components/Batch21Graduates.tsx
+++ b/packages/nextjs/components/Batch21Graduates.tsx
@@ -178,6 +178,7 @@ export const Batch21Graduates: React.FC = () => {
                     "
                   >
                     <div className="w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full overflow-hidden border-2 border-indigo-200 mb-2 sm:mb-3 shadow-sm transition">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img src={avatarUrl} alt={`avatar ${g.owner}`} className="w-full h-full object-cover" />
                     </div>
 

--- a/packages/nextjs/components/GraduateItem.tsx
+++ b/packages/nextjs/components/GraduateItem.tsx
@@ -1,41 +1,43 @@
-"use client";
-
+import { useEffect } from "react";
 import Link from "next/link";
 import { Address } from "~~/components/scaffold-eth/Address/Address";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth/useScaffoldReadContract";
 
 type Props = {
   tokenId: number;
-  chainId: any;
+  handleNftLoaded?: (id: number) => void;
 };
 
 function decodeBase64Json(dataUrl: string): { name?: string; image?: string } | undefined {
   try {
     const prefix = "data:application/json;base64,";
-    if (!dataUrl || !dataUrl.startsWith(prefix)) return undefined;
+    if (!dataUrl?.startsWith(prefix)) return undefined;
+
     const b64 = dataUrl.slice(prefix.length);
     const jsonStr = typeof atob === "function" ? atob(b64) : Buffer.from(b64, "base64").toString("utf-8");
-    const json = JSON.parse(jsonStr);
-    return { name: json.name, image: json.image };
+    return JSON.parse(jsonStr);
   } catch {
     return undefined;
   }
 }
 
-export const GraduateItem = ({ tokenId, chainId }: Props) => {
+export const GraduateItem = ({ tokenId, handleNftLoaded }: Props) => {
   const { data: owner } = useScaffoldReadContract({
     contractName: "BatchGraduationNFT",
     functionName: "ownerOf",
     args: [BigInt(tokenId)],
-    chainId,
   });
 
   const { data: tokenURI } = useScaffoldReadContract({
     contractName: "BatchGraduationNFT",
     functionName: "tokenURI",
     args: [BigInt(tokenId)],
-    chainId,
+    query: { enabled: !!owner },
   });
+
+  useEffect(() => {
+    if (owner && handleNftLoaded) handleNftLoaded(tokenId);
+  }, [owner, handleNftLoaded, tokenId]);
 
   if (!owner) return null;
 

--- a/packages/nextjs/components/GraduateItem.tsx
+++ b/packages/nextjs/components/GraduateItem.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { Address } from "~~/components/scaffold-eth/Address/Address";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth/useScaffoldReadContract";
+
+type Props = {
+  tokenId: number;
+  chainId: any;
+};
+
+function decodeBase64Json(dataUrl: string): { name?: string; image?: string } | undefined {
+  try {
+    const prefix = "data:application/json;base64,";
+    if (!dataUrl || !dataUrl.startsWith(prefix)) return undefined;
+    const b64 = dataUrl.slice(prefix.length);
+    const jsonStr = typeof atob === "function" ? atob(b64) : Buffer.from(b64, "base64").toString("utf-8");
+    const json = JSON.parse(jsonStr);
+    return { name: json.name, image: json.image };
+  } catch {
+    return undefined;
+  }
+}
+
+export const GraduateItem = ({ tokenId, chainId }: Props) => {
+  const { data: owner } = useScaffoldReadContract({
+    contractName: "BatchGraduationNFT",
+    functionName: "ownerOf",
+    args: [BigInt(tokenId)],
+    chainId,
+  });
+
+  const { data: tokenURI } = useScaffoldReadContract({
+    contractName: "BatchGraduationNFT",
+    functionName: "tokenURI",
+    args: [BigInt(tokenId)],
+    chainId,
+  });
+
+  if (!owner) return null;
+
+  const parsed = decodeBase64Json(tokenURI ?? "");
+  const name = parsed?.name;
+
+  return (
+    <Link href={`/builders/${owner}`} className="block w-full h-full min-w-0 py-2">
+      <div className="relative bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 flex flex-col items-center shadow transition hover:-translate-y-1 hover:shadow-xl hover:border-indigo-300 min-w-0">
+        <div className="w-full overflow-hidden truncate">
+          <Address address={owner as `0x${string}`} size="sm" disableAddressLink onlyEnsOrAddress />
+        </div>
+
+        <div className="mt-1 w-full text-center text-xs text-gray-500 dark:text-gray-300 truncate">{name}</div>
+      </div>
+    </Link>
+  );
+};


### PR DESCRIPTION
## Description

Added a new Batch 21 Graduates (“Hall of Fame”) component to display addresses that have received their graduation NFTs.
The component fetches all minted NFT holders from the BatchGraduationNFT contract using ownerOf and tokenURI, decodes the on-chain metadata, and renders each graduate in a responsive card grid.

- Limited the max scanning of tokens to 20.

<img width="777" height="364" alt="Screenshot 2025-11-02 at 5 12 00 PM" src="https://github.com/user-attachments/assets/f9edfd44-c532-4025-9a5a-b32117ff6261" />

- Currently there are no graduate NFTs minted, so component is empty.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


