### PR TITLE
feat: added basic builders page and subgraph integration

### DIFF
--- a/packages/nextjs/app/Providers.tsx
+++ b/packages/nextjs/app/Providers.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { QueryClient, QueryClientProvider, isServer } from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // With SSR, we usually want to set some default staleTime
+        // above 0 to avoid refetching immediately on the client
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}
+let browserQueryClient: QueryClient | undefined = undefined;
+function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+export default function Providers({ children }: Readonly<{ children: React.ReactNode }>) {
+  const queryClient = getQueryClient();
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -16,7 +16,9 @@ const url = "https://api.studio.thegraph.com/query/1713875/buidlguidl-batch-21/v
 async function BuildersPage() {
   const buildersPath = path.join(process.cwd(), "app", "builders");
   const files = await fs.readdir(buildersPath, { withFileTypes: true });
-  const buildersPages = new Set(files.filter(file => file.isDirectory()).map(dir => dir.name.toLowerCase()));
+  const buildersPages = Object.fromEntries(
+    files.filter(file => file.isDirectory()).map(dir => [dir.name.toLowerCase(), dir.name]),
+  );
 
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -7,10 +7,7 @@ import BuildersList from "~~/components/BuildersList";
 const query = gql`
   {
     checkedIns {
-      id
-      first
       builder
-      checkInContract
     }
   }
 `;
@@ -19,7 +16,7 @@ const url = "https://api.studio.thegraph.com/query/1713875/buidlguidl-batch-21/v
 async function BuildersPage() {
   const buildersPath = path.join(process.cwd(), "app", "builders");
   const files = await fs.readdir(buildersPath, { withFileTypes: true });
-  const buildersPages = files.filter(file => file.isDirectory()).map(dir => dir.name);
+  const buildersPages = new Set(files.filter(file => file.isDirectory()).map(dir => dir.name.toLowerCase()));
 
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,0 +1,42 @@
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import fs from "fs/promises";
+import { gql, request } from "graphql-request";
+import path from "path";
+import BuildersList from "~~/components/BuildersList";
+
+const query = gql`
+  {
+    checkedIns {
+      id
+      first
+      builder
+      checkInContract
+    }
+  }
+`;
+const url = "https://api.studio.thegraph.com/query/1713875/buidlguidl-batch-21/version/latest";
+
+async function BuildersPage() {
+  const buildersPath = path.join(process.cwd(), "app", "builders");
+  const files = await fs.readdir(buildersPath, { withFileTypes: true });
+  const buildersPages = files.filter(file => file.isDirectory()).map(dir => dir.name);
+
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["data"],
+    async queryFn() {
+      return await request(url, query, {});
+    },
+  });
+
+  return (
+    <div className="flex justify-center align-middle flex-col ">
+      <h1 className="text-center my-5 text-xl font-bold">Batch 21 Builders</h1>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <BuildersList buildersPages={buildersPages} />
+      </HydrationBoundary>
+    </div>
+  );
+}
+
+export default BuildersPage;

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,3 +1,4 @@
+import Providers from "./Providers";
 import "@rainbow-me/rainbowkit/styles.css";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
@@ -14,7 +15,9 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
     <html suppressHydrationWarning>
       <body>
         <ThemeProvider enableSystem>
-          <ScaffoldEthAppWithProviders>{children}</ScaffoldEthAppWithProviders>
+          <ScaffoldEthAppWithProviders>
+            <Providers>{children}</Providers>
+          </ScaffoldEthAppWithProviders>
         </ThemeProvider>
       </body>
     </html>

--- a/packages/nextjs/components/BuildersList.tsx
+++ b/packages/nextjs/components/BuildersList.tsx
@@ -1,6 +1,7 @@
 "use client";
 "use client";
 
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { gql, request } from "graphql-request";
 import { Address } from "~~/components/scaffold-eth";
@@ -10,16 +11,17 @@ const url = "https://api.studio.thegraph.com/query/1713875/buidlguidl-batch-21/v
 const query = gql`
   {
     checkedIns {
-      id
-      first
       builder
-      checkInContract
     }
   }
 `;
 
 interface BuildersListProps {
-  buildersPages: string[];
+  buildersPages: Set<string>;
+}
+
+interface BuilderQueryResponse {
+  builder: string;
 }
 
 export default function BuildersList({ buildersPages }: BuildersListProps) {
@@ -32,17 +34,28 @@ export default function BuildersList({ buildersPages }: BuildersListProps) {
     },
   });
 
-  console.log(buildersPages);
-
   return (
     <div className="flex items-center justify-center h-screen">
-      <ul>
-        {data["checkedIns"].map((item: any, index: any) => (
-          <li key={index}>
-            <div>
+      <ul className="list bg-base-100 rounded-box shadow-md">
+        <li className="p-4 pb-2 text-xs opacity-60 tracking-wide">Checked-In Builders</li>
+
+        {data["checkedIns"].map((item: BuilderQueryResponse, index: number) => (
+          <li key={index} className="list-row">
+            <div className="text-4xl font-thin opacity-30 tabular-nums">{index + 1}</div>
+
+            <div className="list-col-grow">
               <Address onlyEnsOrAddress={true} address={item["builder"]} />
-              {item["builder"]}
             </div>
+
+            {buildersPages.has(item["builder"]) ? (
+              <Link className="btn btn-secondary btn-sm self-end" href={`/builders/${item["builder"]}`}>
+                <p>Builder Page</p>
+              </Link>
+            ) : (
+              <div className="btn btn-secondary btn-sm btn-disabled self-end">
+                <p> Builder Page</p>
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/packages/nextjs/components/BuildersList.tsx
+++ b/packages/nextjs/components/BuildersList.tsx
@@ -17,7 +17,7 @@ const query = gql`
 `;
 
 interface BuildersListProps {
-  buildersPages: Set<string>;
+  buildersPages: { [k: string]: string };
 }
 
 interface BuilderQueryResponse {
@@ -47,8 +47,8 @@ export default function BuildersList({ buildersPages }: BuildersListProps) {
               <Address onlyEnsOrAddress={true} address={item["builder"]} />
             </div>
 
-            {buildersPages.has(item["builder"]) ? (
-              <Link className="btn btn-secondary btn-sm self-end" href={`/builders/${item["builder"]}`}>
+            {buildersPages.hasOwnProperty(item["builder"]) ? (
+              <Link className="btn btn-secondary btn-sm self-end" href={`/builders/${buildersPages[item["builder"]]}`}>
                 <p>Builder Page</p>
               </Link>
             ) : (

--- a/packages/nextjs/components/BuildersList.tsx
+++ b/packages/nextjs/components/BuildersList.tsx
@@ -1,0 +1,51 @@
+"use client";
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { gql, request } from "graphql-request";
+import { Address } from "~~/components/scaffold-eth";
+
+const url = "https://api.studio.thegraph.com/query/1713875/buidlguidl-batch-21/version/latest";
+
+const query = gql`
+  {
+    checkedIns {
+      id
+      first
+      builder
+      checkInContract
+    }
+  }
+`;
+
+interface BuildersListProps {
+  buildersPages: string[];
+}
+
+export default function BuildersList({ buildersPages }: BuildersListProps) {
+  // the data is already pre-fetched on the server and immediately available here,
+  // without an additional network call
+  const { data } = useQuery({
+    queryKey: ["data"],
+    async queryFn() {
+      return await request(url, query, {});
+    },
+  });
+
+  console.log(buildersPages);
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <ul>
+        {data["checkedIns"].map((item: any, index: any) => (
+          <li key={index}>
+            <div>
+              <Address onlyEnsOrAddress={true} address={item["builder"]} />
+              {item["builder"]}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -26,6 +26,8 @@
     "blo": "^1.2.0",
     "burner-connector": "0.0.18",
     "daisyui": "^5.0.9",
+    "graphql": "^16.12.0",
+    "graphql-request": "^7.3.1",
     "kubo-rpc-client": "^5.0.2",
     "next": "^15.2.3",
     "next-nprogress-bar": "^2.3.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,6 +1703,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-typed-document-node/core@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@graphql-typed-document-node/core@npm:3.2.0"
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: fa44443accd28c8cf4cb96aaaf39d144a22e8b091b13366843f4e97d19c7bfeaf609ce3c7603a4aeffe385081eaf8ea245d078633a7324c11c5ec4b2011bb76d
+  languageName: node
+  linkType: hard
+
 "@heroicons/react@npm:^2.1.5":
   version: 2.1.5
   resolution: "@heroicons/react@npm:2.1.5"
@@ -4108,6 +4117,8 @@ __metadata:
     eslint-config-next: ^15.2.3
     eslint-config-prettier: ^10.1.1
     eslint-plugin-prettier: ^5.2.4
+    graphql: ^16.12.0
+    graphql-request: ^7.3.1
     kubo-rpc-client: ^5.0.2
     next: ^15.2.3
     next-nprogress-bar: ^2.3.13
@@ -11141,6 +11152,24 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: bab8f0be9b568857c7bec9fda95a89f87b783546d02951c40c33f84d05bb7da3fd10f863a9beb901463669b6583173a8c8cc6d6b306ea2b9b9d5d3d943c3a673
+  languageName: node
+  linkType: hard
+
+"graphql-request@npm:^7.3.1":
+  version: 7.3.1
+  resolution: "graphql-request@npm:7.3.1"
+  dependencies:
+    "@graphql-typed-document-node/core": ^3.2.0
+  peerDependencies:
+    graphql: 14 - 16
+  checksum: 6a93ca279a8890f2de2ae77deb950e1f9b8988512e68a0a0179ea347a1536fbc8520f316d5c79788f588254eb4e93f2bebfa9c560b2028eab41b1c8433441a18
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.12.0":
+  version: 16.12.0
+  resolution: "graphql@npm:16.12.0"
+  checksum: c0d2435425270c575091861c9fd82d7cebc1fb1bd5461e05c36521a988f69c5074461e27b89ab70851fabc72ec9d988235f288ba7bbeff67d08a973e8b9d6d3d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Deployed Subgraph for Smart Contracts. 

- Added Required Packages for Subgraph Queries on the frontend.

- Building Builders Page.


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Closes #4 

## Screenshots 

<img width="5088" height="3368" alt="image" src="https://github.com/user-attachments/assets/b45dd6f6-128d-4f6a-9481-ba897981ca9e" />

Your ENS/address:

0xE451141fCE63EB38e85F08a991fC5878Ee6335b2
